### PR TITLE
Add repo field to package.json for provenance

### DIFF
--- a/apps/indexer/package.json
+++ b/apps/indexer/package.json
@@ -11,6 +11,7 @@
     "lint": "biome lint",
     "test:it": "vitest"
   },
+  "repository": "github:Sovereign-Labs/sovereign-sdk-web3-js",
   "bin": {
     "indexer": "./bin/sov-indexer"
   },

--- a/packages/signers/package.json
+++ b/packages/signers/package.json
@@ -9,6 +9,7 @@
     "lint": "biome lint",
     "test": "vitest"
   },
+  "repository": "github:Sovereign-Labs/sovereign-sdk-web3-js",
   "files": ["dist", "README.md", "package.json"],
   "exports": {
     ".": {

--- a/packages/universal-wallet-wasm/package.json
+++ b/packages/universal-wallet-wasm/package.json
@@ -7,6 +7,7 @@
     "compile:node": "wasm-pack build --target nodejs --release --out-dir dist/node",
     "test": "pnpm compile:node && vitest"
   },
+  "repository": "github:Sovereign-Labs/sovereign-sdk-web3-js",
   "files": [
     "dist/**/*",
     "!dist/**/.gitignore",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -9,6 +9,7 @@
     "lint": "biome lint",
     "test": "vitest"
   },
+  "repository": "github:Sovereign-Labs/sovereign-sdk-web3-js",
   "files": ["dist", "README.md", "package.json"],
   "exports": {
     ".": {

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -9,6 +9,7 @@
     "typecheck": "tsc --noEmit",
     "test": "vitest"
   },
+  "repository": "github:Sovereign-Labs/sovereign-sdk-web3-js",
   "files": ["dist", "package.json"],
   "exports": {
     ".": {


### PR DESCRIPTION
## Description

Adds repository to `package.json`, it is required for publishing packages to NPM with provenance.

## Related Issues

#148 

## Checklist

- [x] PR contains a changeset entry with minor version bump if it contains any breaking changes ([see here for explanation](../DEVELOPMENT.md#changesets-in-monorepo))
