### PR TITLE
Add `modules` package

### DIFF
--- a/.changeset/thirty-masks-flow.md
+++ b/.changeset/thirty-masks-flow.md
@@ -1,0 +1,5 @@
+---
+"@sovereign-sdk/modules": patch
+---
+
+introduces the `modules` package containing Bank module helper

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@sovereign-sdk/modules",
   "version": "0.0.1",
-  "description": "",
+  "description": "A package providing convenient helpers for interacting with core Sovereign SDK modules",
   "scripts": {
     "build": "tsup",
     "ci": "biome ci",

--- a/packages/modules/package.json
+++ b/packages/modules/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@sovereign-sdk/modules",
+  "version": "0.0.1",
+  "description": "",
+  "scripts": {
+    "build": "tsup",
+    "ci": "biome ci",
+    "fix": "biome check --write",
+    "lint": "biome lint",
+    "test": "vitest"
+  },
+  "repository": "github:Sovereign-Labs/sovereign-sdk-web3-js",
+  "files": ["dist", "README.md", "package.json"],
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs"
+    }
+  },
+  "main": "./dist/index.js",
+  "module": "./dist/index.mjs",
+  "types": "./dist/index.d.ts",
+  "devDependencies": {
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.3",
+    "vitest": "^3.0.5"
+  },
+  "peerDependencies": {
+    "tsup": "^8.3.0",
+    "typescript": "^5.6.3"
+  },
+  "publishConfig": {
+    "access": "public"
+  },
+  "dependencies": {
+    "@sovereign-sdk/web3": "workspace:^",
+    "@sovereign-sdk/utils": "workspace:^"
+  }
+}

--- a/packages/modules/src/bank.test.ts
+++ b/packages/modules/src/bank.test.ts
@@ -1,0 +1,282 @@
+import { SovereignClient } from "@sovereign-sdk/web3";
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { Bank } from "./bank";
+
+describe("Bank", () => {
+  let mockRollup: any;
+  let mockClient: any;
+  let bank: Bank;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+
+    mockClient = {
+      get: vi.fn(),
+    };
+
+    mockRollup = {
+      http: mockClient,
+    };
+
+    bank = new Bank(mockRollup);
+  });
+
+  describe("balance", () => {
+    const mockAddress = "0x1234567890abcdef";
+    const mockTokenId = "token_123";
+    const mockGasTokenId = "gas_token_456";
+
+    beforeEach(() => {
+      // Mock gasTokenId method
+      vi.spyOn(bank, "gasTokenId").mockResolvedValue(mockGasTokenId);
+    });
+
+    it("should return balance for a specific token", async () => {
+      const mockResponse = {
+        data: {
+          amount: "1000000000000000000",
+          token_id: mockTokenId,
+        },
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const result = await bank.balance(mockAddress, mockTokenId);
+
+      expect(mockClient.get).toHaveBeenCalledWith(
+        `/modules/bank/tokens/${mockTokenId}/balances/${mockAddress}`,
+      );
+      expect(result).toBe(BigInt("1000000000000000000"));
+    });
+
+    it("should return balance for gas token when no tokenId provided", async () => {
+      const mockResponse = {
+        data: {
+          amount: "500000000000000000",
+          token_id: mockGasTokenId,
+        },
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const result = await bank.balance(mockAddress);
+
+      expect(mockClient.get).toHaveBeenCalledWith(
+        `/modules/bank/tokens/${mockGasTokenId}/balances/${mockAddress}`,
+      );
+      expect(result).toBe(BigInt("500000000000000000"));
+    });
+
+    it("should return 0 for missing account", async () => {
+      const apiError = new SovereignClient.APIError(
+        404,
+        {
+          errors: [
+            {
+              title: "Balance 'sov1lkjo2jiojoj' not found",
+            },
+          ],
+        },
+        undefined,
+        undefined,
+      );
+
+      mockClient.get.mockRejectedValue(apiError);
+
+      const result = await bank.balance(mockAddress, mockTokenId);
+
+      expect(result).toBe(BigInt(0));
+    });
+
+    it("should throw error for non-404 API errors", async () => {
+      const apiError = {
+        status: 500,
+        error: {
+          errors: [
+            {
+              title: "Internal server error",
+            },
+          ],
+        },
+      };
+
+      mockClient.get.mockRejectedValue(apiError);
+
+      await expect(bank.balance(mockAddress, mockTokenId)).rejects.toEqual(
+        apiError,
+      );
+    });
+
+    it("should throw error for non-API errors", async () => {
+      const networkError = new Error("Network error");
+      mockClient.get.mockRejectedValue(networkError);
+
+      await expect(bank.balance(mockAddress, mockTokenId)).rejects.toThrow(
+        "Network error",
+      );
+    });
+
+    it("should throw error for 404 with non-balance error title", async () => {
+      const apiError = {
+        status: 404,
+        error: {
+          errors: [
+            {
+              title: "Something else not found",
+            },
+          ],
+        },
+      };
+
+      mockClient.get.mockRejectedValue(apiError);
+
+      await expect(bank.balance(mockAddress, mockTokenId)).rejects.toEqual(
+        apiError,
+      );
+    });
+
+    it("should throw error for 404 with empty errors array", async () => {
+      const apiError = {
+        status: 404,
+        error: {
+          errors: [],
+        },
+      };
+
+      mockClient.get.mockRejectedValue(apiError);
+
+      await expect(bank.balance(mockAddress, mockTokenId)).rejects.toEqual(
+        apiError,
+      );
+    });
+  });
+
+  describe("totalSupply", () => {
+    const mockTokenId = "token_123";
+    const mockGasTokenId = "gas_token_456";
+
+    beforeEach(() => {
+      // Mock gasTokenId method
+      vi.spyOn(bank, "gasTokenId").mockResolvedValue(mockGasTokenId);
+    });
+
+    it("should return total supply for a specific token", async () => {
+      const mockResponse = {
+        data: {
+          amount: "1000000000000000000000000",
+          token_id: mockTokenId,
+        },
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const result = await bank.totalSupply(mockTokenId);
+
+      expect(mockClient.get).toHaveBeenCalledWith(
+        `/modules/bank/tokens/${mockTokenId}/total-supply`,
+      );
+      expect(result).toBe(BigInt("1000000000000000000000000"));
+    });
+
+    it("should return total supply for gas token when no tokenId provided", async () => {
+      const mockResponse = {
+        data: {
+          amount: "500000000000000000000000",
+          token_id: mockGasTokenId,
+        },
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const result = await bank.totalSupply();
+
+      expect(mockClient.get).toHaveBeenCalledWith(
+        `/modules/bank/tokens/${mockGasTokenId}/total-supply`,
+      );
+      expect(result).toBe(BigInt("500000000000000000000000"));
+    });
+
+    it("should throw error when API request fails", async () => {
+      const apiError = {
+        status: 500,
+        error: {
+          errors: [
+            {
+              title: "Internal server error",
+            },
+          ],
+        },
+      };
+
+      mockClient.get.mockRejectedValue(apiError);
+
+      await expect(bank.totalSupply(mockTokenId)).rejects.toEqual(apiError);
+    });
+  });
+
+  describe("gasTokenId", () => {
+    it("should return cached gas token ID on subsequent calls", async () => {
+      const mockResponse = {
+        data: {
+          token_id: "gas_token_123",
+        },
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      // First call
+      const result1 = await bank.gasTokenId();
+      expect(result1).toBe("gas_token_123");
+      expect(mockClient.get).toHaveBeenCalledTimes(1);
+
+      // Second call should use cache
+      const result2 = await bank.gasTokenId();
+      expect(result2).toBe("gas_token_123");
+      expect(mockClient.get).toHaveBeenCalledTimes(1); // Still only called once
+    });
+
+    it("should make API call to get gas token ID on first call", async () => {
+      const mockResponse = {
+        data: {
+          token_id: "gas_token_456",
+        },
+      };
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      const result = await bank.gasTokenId();
+
+      expect(mockClient.get).toHaveBeenCalledWith(
+        "/modules/bank/tokens/gas_token",
+      );
+      expect(result).toBe("gas_token_456");
+    });
+
+    it("should throw error when API request fails", async () => {
+      const apiError = {
+        status: 500,
+        error: {
+          errors: [
+            {
+              title: "Internal server error",
+            },
+          ],
+        },
+      };
+
+      mockClient.get.mockRejectedValue(apiError);
+
+      await expect(bank.gasTokenId()).rejects.toEqual(apiError);
+    });
+
+    it("should throw error when response data is missing", async () => {
+      const mockResponse = {};
+
+      mockClient.get.mockResolvedValue(mockResponse);
+
+      await expect(bank.gasTokenId()).rejects.toThrow(
+        "data field missing from response",
+      );
+    });
+  });
+});

--- a/packages/modules/src/bank.ts
+++ b/packages/modules/src/bank.ts
@@ -1,0 +1,139 @@
+import { type Rollup, SovereignClient } from "@sovereign-sdk/web3";
+import { type ErrorResponse, type Response, isSuccessResponse } from "./types";
+
+type GasTokenIdPayload = {
+  token_id: string;
+};
+
+type BalancePayload = {
+  amount: string;
+  token_id: string;
+};
+
+type TotalSupplyPayload = {
+  amount: string;
+  token_id: string;
+};
+
+/**
+ * Bank class for interacting with the Sovereign SDK Bank module.
+ */
+export class Bank {
+  // biome-ignore lint/suspicious/noExplicitAny: types arent used
+  private readonly rollup: Rollup<any, any>;
+  private _gasTokenId?: string;
+
+  /**
+   * Creates a new Bank instance.
+   *
+   * @param rollup - The rollup instance to use for HTTP requests
+   */
+  // biome-ignore lint/suspicious/noExplicitAny: types arent used
+  constructor(rollup: Rollup<any, any>) {
+    this.rollup = rollup;
+  }
+
+  /**
+   * Gets the balance of a specific token for a given address.
+   *
+   * If no token ID is provided, the gas token balance will be returned.
+   *
+   * @param address - The address to query the balance for
+   * @param tokenId - Optional token ID. If not provided, uses the gas token
+   * @returns Promise resolving to the token balance as a bigint
+   * @throws {SovereignClient.APIError} When the request fails for reasons other than missing account
+   * @example
+   * ```typescript
+   * const bank = new Bank(rollup);
+   * const balance = await bank.balance("0x123...");
+   * console.log(`Balance: ${balance}`);
+   *
+   * // Query specific token balance
+   * const tokenBalance = await bank.balance("0x123...", "token_123");
+   * ```
+   */
+  async balance(address: string, tokenId?: string): Promise<bigint> {
+    const token = await this.tokenIdOrElseGasTokenId(tokenId);
+
+    try {
+      const response: Response<BalancePayload> = await this.rollup.http.get(
+        `/modules/bank/tokens/${token}/balances/${address}`,
+      );
+
+      isSuccessResponse(response);
+      return BigInt(response.data.amount);
+    } catch (e) {
+      const err = e as SovereignClient.APIError;
+
+      if (this.isMissingAccountError(err)) return BigInt(0);
+
+      throw e;
+    }
+  }
+
+  /**
+   * Gets the total supply of a specific token.
+   *
+   * If no token ID is provided, returns the total supply of the gas token.
+   *
+   * @param tokenId - Optional token ID. If not provided, uses the gas token
+   * @returns Promise resolving to the total supply as a bigint
+   * @throws {SovereignClient.APIError} When the request fails
+   * @example
+   * ```typescript
+   * const bank = new Bank(rollup);
+   * const totalSupply = await bank.totalSupply();
+   * console.log(`Total gas token supply: ${totalSupply}`);
+   *
+   * // Query specific token supply
+   * const tokenSupply = await bank.totalSupply("token_123");
+   * ```
+   */
+  async totalSupply(tokenId?: string): Promise<bigint> {
+    const token = await this.tokenIdOrElseGasTokenId(tokenId);
+    const response: Response<TotalSupplyPayload> = await this.rollup.http.get(
+      `/modules/bank/tokens/${token}/total-supply`,
+    );
+    isSuccessResponse(response);
+    return BigInt(response.data.amount);
+  }
+
+  /**
+   * Gets the gas token identifier.
+   *
+   * The gas token ID is cached after the first request to avoid repeated API calls.
+   *
+   * @returns Promise resolving to the gas token ID as a string
+   * @throws {Error} When the gas token ID cannot be retrieved
+   * @example
+   * ```typescript
+   * const bank = new Bank(rollup);
+   * const gasTokenId = await bank.gasTokenId();
+   * console.log(`Gas token ID: ${gasTokenId}`);
+   * ```
+   */
+  async gasTokenId(): Promise<string> {
+    if (this._gasTokenId) return this._gasTokenId;
+    const response: Response<GasTokenIdPayload> = await this.rollup.http.get(
+      "/modules/bank/tokens/gas_token",
+    );
+    isSuccessResponse(response);
+    this._gasTokenId = response.data.token_id;
+    return this._gasTokenId;
+  }
+
+  private async tokenIdOrElseGasTokenId(tokenId?: string): Promise<string> {
+    return tokenId ?? this.gasTokenId();
+  }
+
+  private isMissingAccountError(anyError: unknown): boolean {
+    if (!(anyError instanceof SovereignClient.APIError)) return false;
+    if (anyError.status !== 404) return false;
+    const body = anyError.error as ErrorResponse;
+    const error = body.errors[0];
+    if (!error) return false;
+    return (
+      error.title.startsWith("Balance") && error.title.endsWith("not found")
+    );
+  }
+}

--- a/packages/modules/src/index.ts
+++ b/packages/modules/src/index.ts
@@ -1,0 +1,1 @@
+export * from "./bank";

--- a/packages/modules/src/types.ts
+++ b/packages/modules/src/types.ts
@@ -1,0 +1,21 @@
+export type SuccessResponse<T> = {
+  data: T;
+};
+
+export type ErrorResponse = {
+  data: undefined;
+  errors: {
+    status: number;
+    title: string;
+    details: Record<string, unknown>;
+  }[];
+};
+
+export type Response<T> = SuccessResponse<T> | ErrorResponse;
+
+export function isSuccessResponse<T>(
+  response: Response<T>,
+): asserts response is SuccessResponse<T> {
+  if (response.data === undefined)
+    throw new Error("data field missing from response");
+}

--- a/packages/modules/tsconfig.json
+++ b/packages/modules/tsconfig.json
@@ -1,0 +1,3 @@
+{
+  "extends": "../../tsconfig.json"
+}

--- a/packages/modules/tsup.config.ts
+++ b/packages/modules/tsup.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["cjs", "esm"],
+  splitting: false,
+  sourcemap: true,
+  clean: true,
+  dts: true,
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -85,7 +85,7 @@ importers:
         version: 2.1.0
       '@types/bun':
         specifier: latest
-        version: 1.2.15
+        version: 1.2.17
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.7.42)(@types/node@22.7.5)(typescript@5.6.3)
@@ -98,6 +98,9 @@ importers:
       '@noble/hashes':
         specifier: ^1.5.0
         version: 1.5.0
+      '@sovereign-sdk/modules':
+        specifier: workspace:^
+        version: link:../modules
       '@sovereign-sdk/signers':
         specifier: workspace:^
         version: link:../signers
@@ -113,6 +116,25 @@ importers:
       ts-node:
         specifier: ^10.9.2
         version: 10.9.2(@swc/core@1.7.42)(@types/node@22.7.5)(typescript@5.6.3)
+      typescript:
+        specifier: ^5.6.3
+        version: 5.6.3
+      vitest:
+        specifier: ^3.0.5
+        version: 3.0.5(@types/debug@4.1.12)(@types/node@22.7.5)(yaml@2.7.1)
+
+  packages/modules:
+    dependencies:
+      '@sovereign-sdk/utils':
+        specifier: workspace:^
+        version: link:../utils
+      '@sovereign-sdk/web3':
+        specifier: workspace:^
+        version: link:../web3
+    devDependencies:
+      tsup:
+        specifier: ^8.3.0
+        version: 8.3.0(@swc/core@1.7.42)(postcss@8.5.3)(typescript@5.6.3)(yaml@2.7.1)
       typescript:
         specifier: ^5.6.3
         version: 5.6.3
@@ -1145,8 +1167,8 @@ packages:
   '@tsconfig/node16@1.0.4':
     resolution: {integrity: sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==}
 
-  '@types/bun@1.2.15':
-    resolution: {integrity: sha512-U1ljPdBEphF0nw1MIk0hI7kPg7dFdPyM7EenHsp6W5loNHl7zqy6JQf/RKCgnUn2KDzUpkBwHPnEJEjII594bA==}
+  '@types/bun@1.2.17':
+    resolution: {integrity: sha512-l/BYs/JYt+cXA/0+wUhulYJB6a6p//GTPiJ7nV+QHa8iiId4HZmnu/3J/SowP5g0rTiERY2kfGKXEK5Ehltx4Q==}
 
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
@@ -1414,8 +1436,8 @@ packages:
     resolution: {integrity: sha512-8f9ZJCUXyT1M35Jx7MkBgmBMo3oHTTBIPLiY9xyL0pl3T5RwcPEY8cUHr5LBNfu/fk6c2T4DJZuVM/8ZZT2D2A==}
     engines: {node: '>=10.0.0'}
 
-  bun-types@1.2.15:
-    resolution: {integrity: sha512-NarRIaS+iOaQU1JPfyKhZm4AsUOrwUOqRNHY0XxI8GI8jYxiLXLcdjYMG9UKS+fwWasc1uw1htV9AX24dD+p4w==}
+  bun-types@1.2.17:
+    resolution: {integrity: sha512-ElC7ItwT3SCQwYZDYoAH+q6KT4Fxjl8DtZ6qDulUFBmXA8YB4xo+l54J9ZJN+k2pphfn9vk7kfubeSd5QfTVJQ==}
 
   bundle-require@5.0.0:
     resolution: {integrity: sha512-GuziW3fSSmopcx4KRymQEJVbZUfqlCqcq7dvs6TYwKRZiegK/2buMxQTPs6MGlNv50wms1699qYO54R8XfRX4w==}
@@ -3698,9 +3720,9 @@ snapshots:
 
   '@tsconfig/node16@1.0.4': {}
 
-  '@types/bun@1.2.15':
+  '@types/bun@1.2.17':
     dependencies:
-      bun-types: 1.2.15
+      bun-types: 1.2.17
 
   '@types/debug@4.1.12':
     dependencies:
@@ -3999,7 +4021,7 @@ snapshots:
   buildcheck@0.0.6:
     optional: true
 
-  bun-types@1.2.15:
+  bun-types@1.2.17:
     dependencies:
       '@types/node': 22.7.5
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,9 +98,6 @@ importers:
       '@noble/hashes':
         specifier: ^1.5.0
         version: 1.5.0
-      '@sovereign-sdk/modules':
-        specifier: workspace:^
-        version: link:../modules
       '@sovereign-sdk/signers':
         specifier: workspace:^
         version: link:../signers

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   test: {
     coverage: {
       provider: "v8",
-      include: includePackages("web3", "signers", "utils"),
+      include: includePackages("web3", "signers", "utils", "modules"),
     },
   },
 });


### PR DESCRIPTION
## Description

Introduces a new package `modules`, that will expose helper classes to interact with core sovereign SDK modules in convenient ways.

A good example for why this is useful is the bank, us and all our customers have needed to implement our own functions for fetching balances, etc, this removes that need.

This could be taken further in the future by providing abstractions for specific, fine-grained subscriptions to the bank module, like `bank.onBalanceChanged`, `bank.onMint`, etc etc
