### PR TITLE
Remove public key when building unsigned tx

### DIFF
--- a/.changeset/new-mangos-doubt.md
+++ b/.changeset/new-mangos-doubt.md
@@ -1,0 +1,5 @@
+---
+"@sovereign-sdk/web3": minor
+---
+
+Removes a signer.publicKey call when constructing an unsigned transaction. This was previously used because we needed the pubkey to get the users nonce, now we use a timestamp generation its not needed - some wallets like privy dont expose the users public key upfront so this also avoids the problem of not having access to the users public key at this point in time

--- a/packages/integration-tests/src/tests/rollup.integration-test.ts
+++ b/packages/integration-tests/src/tests/rollup.integration-test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect } from "vitest";
 import { createStandardRollup, StandardRollup } from "@sovereign-sdk/web3";
 import { getSigner } from "./signer";
 import { Signer } from "@sovereign-sdk/signers";

--- a/packages/web3/src/errors.ts
+++ b/packages/web3/src/errors.ts
@@ -41,7 +41,7 @@ export class SchemaError extends SovereignError {
   public readonly reason: string;
 
   constructor(message: string, reason: string, schema: object) {
-    super(message);
+    super(`${message}: ${reason}`);
 
     this.reason = reason;
     this.schema = schema;

--- a/packages/web3/src/rollup/rollup.test.ts
+++ b/packages/web3/src/rollup/rollup.test.ts
@@ -2,7 +2,7 @@ import SovereignClient from "@sovereign-sdk/client";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 import demoRollupSchema from "../../../__fixtures__/demo-rollup-schema.json";
 import { VersionMismatchError } from "../errors";
-import { type RollupSerializer, createSerializer } from "../serialization";
+import type { RollupSerializer } from "../serialization";
 import type { BaseTypeSpec } from "../type-spec";
 import {
   type PartialRollupConfig,
@@ -335,7 +335,6 @@ describe("Rollup", () => {
 
       expect(mockTypeBuilder.unsignedTransaction).toHaveBeenCalledWith({
         runtimeCall: mockRuntimeCall,
-        sender: new Uint8Array([4, 5, 6]),
         rollup: rollup,
         overrides: mockOverrides,
       });

--- a/packages/web3/src/rollup/rollup.ts
+++ b/packages/web3/src/rollup/rollup.ts
@@ -21,7 +21,6 @@ export type UnsignedTransactionContext<
   C extends RollupContext,
 > = {
   runtimeCall: S["RuntimeCall"];
-  sender: Uint8Array;
   // Provides the ability to override the generation data instead of retrieving it automatically.
   overrides: DeepPartial<S["UnsignedTransaction"]>;
   rollup: Rollup<S, C>;
@@ -237,10 +236,8 @@ export class Rollup<S extends BaseTypeSpec, C extends RollupContext> {
     { signer, overrides }: CallParams<S>,
     options?: SovereignClient.RequestOptions,
   ): Promise<TransactionResult<S["Transaction"]>> {
-    const publicKey = await signer.publicKey();
     const context = {
       runtimeCall,
-      sender: publicKey,
       rollup: this,
       overrides: overrides ?? ({} as DeepPartial<S["UnsignedTransaction"]>),
     };

--- a/packages/web3/src/rollup/standard-rollup.test.ts
+++ b/packages/web3/src/rollup/standard-rollup.test.ts
@@ -42,7 +42,6 @@ describe("standardTypeBuilder", () => {
     it("should use provided generation from overrides", async () => {
       const result = await builder.unsignedTransaction({
         runtimeCall: { foo: "bar" },
-        sender: new Uint8Array([4, 5, 6]),
         overrides: { generation: 10 },
         rollup: mockRollup as any,
       });
@@ -63,7 +62,6 @@ describe("standardTypeBuilder", () => {
 
       const result = await builder.unsignedTransaction({
         runtimeCall: { foo: "bar" },
-        sender: new Uint8Array([4, 5, 6]),
         overrides: {},
         rollup: mockRollup as any,
       });
@@ -84,7 +82,6 @@ describe("standardTypeBuilder", () => {
 
       const result = await builder.unsignedTransaction({
         runtimeCall: { foo: "bar" },
-        sender: new Uint8Array([4, 5, 6]),
         overrides: {
           details: {
             max_fee: "2000",

--- a/packages/web3/src/rollup/standard-rollup.ts
+++ b/packages/web3/src/rollup/standard-rollup.ts
@@ -134,7 +134,6 @@ export class StandardRollup<RuntimeCall> extends Rollup<
     const runtimeCall = this.serializer.serializeRuntimeCall(runtimeMessage);
     const publicKey = await signer.publicKey();
     const generation = await useOrFetchGeneration({
-      sender: publicKey,
       rollup: this,
       overrides: { generation: overrideGeneration },
     });


### PR DESCRIPTION
## Description

Removes a signer.publicKey call when constructing an unsigned transaction. This was previously used because we needed the pubkey to get the users nonce, now we use a timestamp generation its not needed - some wallets like privy dont expose the users public key upfront so this also avoids the problem of not having access to the users public key at this point in time

## Checklist

- [x] PR contains a changeset entry with minor version bump if it contains any breaking changes ([see here for explanation](../DEVELOPMENT.md#changesets-in-monorepo))
