### PR TITLE
Simplifies creating rollup instance

### DIFF
--- a/.changeset/polite-buttons-complain.md
+++ b/.changeset/polite-buttons-complain.md
@@ -1,0 +1,5 @@
+---
+"@sovereign-sdk/web3": minor
+---
+
+Removes the PartialRollupConfig type, just use Partial<RollupConfig<>>, made creating standard rollup easier by providing defaults for all params for creation func

--- a/packages/integration-tests/src/tests/rollup.integration-test.ts
+++ b/packages/integration-tests/src/tests/rollup.integration-test.ts
@@ -13,16 +13,7 @@ const testAddress = {
 describe("rollup", async () => {
   describe.sequential("transaction submission", () => {
     it("should successfully sign and submit a transaction", async () => {
-      rollup = await createStandardRollup({
-        context: {
-          defaultTxDetails: {
-            max_priority_fee_bips: 0,
-            max_fee: "100000000",
-            gas_limit: null,
-            chain_id: 4321,
-          },
-        },
-      });
+      rollup = await createStandardRollup();
       signer = getSigner(rollup.chainHash);
       const runtimeCall = {
         bank: {
@@ -42,16 +33,7 @@ describe("rollup", async () => {
       expect(response.data!.status).toEqual("submitted");
     });
     it("should submit a batch with manually incrementing nonces successfully", async () => {
-      rollup = await createStandardRollup({
-        context: {
-          defaultTxDetails: {
-            max_priority_fee_bips: 0,
-            max_fee: "100000000",
-            gas_limit: null,
-            chain_id: 4321,
-          },
-        },
-      });
+      rollup = await createStandardRollup();
       signer = getSigner(rollup.chainHash);
       const publicKey = await signer.publicKey();
       let { nonce } = await rollup.dedup(publicKey);

--- a/packages/web3/src/rollup/rollup.test.ts
+++ b/packages/web3/src/rollup/rollup.test.ts
@@ -5,8 +5,8 @@ import { VersionMismatchError } from "../errors";
 import type { RollupSerializer } from "../serialization";
 import type { BaseTypeSpec } from "../type-spec";
 import {
-  type PartialRollupConfig,
   Rollup,
+  type RollupConfig,
   type RollupContext,
   type TypeBuilder,
 } from "./rollup";
@@ -20,7 +20,7 @@ const mockSerializer: RollupSerializer = {
 };
 
 const testRollup = <S extends BaseTypeSpec, C extends RollupContext>(
-  config?: Partial<PartialRollupConfig<C>>,
+  config?: Partial<RollupConfig<C>>,
   builder?: Partial<TypeBuilder<S, C>>,
 ) =>
   new Rollup(

--- a/packages/web3/src/rollup/rollup.ts
+++ b/packages/web3/src/rollup/rollup.ts
@@ -51,11 +51,8 @@ export type RollupContext = Record<string, unknown>;
 
 /**
  * The configuration for a rollup client.
- * This is a partial version of the configuration object, using a partial version
- * allows setup code to initialize fields automatically for SDK users, for example
- * fetching a `serializer` instance from the rollups endpoint.
  */
-export type PartialRollupConfig<C extends RollupContext> = {
+export type RollupConfig<C extends RollupContext> = {
   /**
    * The base URL of the rollup full node API.
    */
@@ -64,27 +61,16 @@ export type PartialRollupConfig<C extends RollupContext> = {
    * The Sovereign SDK client to use for the rollup.
    * If not provided, the default client will be used using {@link PartialRollupConfig.url}.
    */
-  client?: SovereignClient;
+  client: SovereignClient;
   /**
    * The serializer to use for the rollup.
    * If not provided, a serializer will be created using the provided client and the rollup HTTP endpoint.
    */
-  serializer?: RollupSerializer;
+  serializer: RollupSerializer;
   /**
    * Arbitrary context that is associated with the rollup.
    */
   context: C;
-};
-
-/**
- * Fully initialized rollup configuration.
- */
-export type RollupConfig<C extends RollupContext> = Omit<
-  PartialRollupConfig<C>,
-  "client" | "serializer"
-> & {
-  client: SovereignClient;
-  serializer: RollupSerializer;
 };
 
 /**


### PR DESCRIPTION
## Description

Previously users were forced to provide params for tx details/chain id when creating the rollup, this was often copy and pasted + users need to go look for chain id:

```ts
rollup = await createStandardRollup({
  context: {
    defaultTxDetails: {
      max_priority_fee_bips: 0,
      max_fee: "100000000",
      gas_limit: null,
      chain_id: 4321,
    },
  },
});
```

Now we provide defaults for tx details and automatically fetch the chain id from the rollups rest api so we can just do:

```ts
const rollup = await createStandardRollup();
```

And still optionally pass those values if desired.

## Related Issues

Closes ##172