### PR TITLE
Integrate serializers package into web3 package

### DIFF
--- a/.changeset/sixty-apes-rule.md
+++ b/.changeset/sixty-apes-rule.md
@@ -1,0 +1,5 @@
+---
+"@sovereign-sdk/web3": minor
+---
+
+integrates `serializers` package into main web3 package & updates http client version

--- a/packages/web3/package.json
+++ b/packages/web3/package.json
@@ -29,8 +29,9 @@
     "typescript": "^5.0.0"
   },
   "dependencies": {
-    "@sovereign-sdk/client": "0.1.0-alpha.35",
+    "@sovereign-sdk/client": "0.1.0-alpha.36",
     "@sovereign-sdk/signers": "workspace:^",
+    "@sovereign-sdk/serializers": "workspace:^",
     "@sovereign-sdk/universal-wallet-wasm": "workspace:^",
     "@sovereign-sdk/utils": "workspace:^",
     "bech32": "^2.0.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,6 +88,10 @@ importers:
         version: 10.9.2(@swc/core@1.7.42)(@types/node@22.7.5)(typescript@5.6.3)
 
   packages/integration-tests:
+    dependencies:
+      tsx:
+        specifier: ^4.20.3
+        version: 4.20.3
     devDependencies:
       '@noble/ed25519':
         specifier: ^2.1.0
@@ -95,6 +99,9 @@ importers:
       '@noble/hashes':
         specifier: ^1.5.0
         version: 1.5.0
+      '@sovereign-sdk/serializers':
+        specifier: workspace:^
+        version: link:../serializers
       '@sovereign-sdk/signers':
         specifier: workspace:^
         version: link:../signers
@@ -242,8 +249,11 @@ importers:
   packages/web3:
     dependencies:
       '@sovereign-sdk/client':
-        specifier: 0.1.0-alpha.35
-        version: 0.1.0-alpha.35
+        specifier: 0.1.0-alpha.36
+        version: 0.1.0-alpha.36
+      '@sovereign-sdk/serializers':
+        specifier: workspace:^
+        version: link:../serializers
       '@sovereign-sdk/signers':
         specifier: workspace:^
         version: link:../signers
@@ -1093,8 +1103,8 @@ packages:
   '@shikijs/vscode-textmate@10.0.2':
     resolution: {integrity: sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==}
 
-  '@sovereign-sdk/client@0.1.0-alpha.35':
-    resolution: {integrity: sha512-DkORDXRyM71TDg3+v9HhyMzG9CrmVtQTegKvg0wBfylly5LoQxWPUGYFKJ5pAgOCLnd+RJ64TGWg7IiNXpMRMw==}
+  '@sovereign-sdk/client@0.1.0-alpha.36':
+    resolution: {integrity: sha512-avDO8co/+YRmMIG1+LcPP3ANDIJAbefz3tY155ozKSWfWQNJ8WC5DPKXiiMwxkGU4cPeO1LHgVhNg+Ho6FzcHg==}
 
   '@swc/core-darwin-arm64@1.7.42':
     resolution: {integrity: sha512-fWhaCs2+8GDRIcjExVDEIfbptVrxDqG8oHkESnXgymmvqTWzWei5SOnPNMS8Q+MYsn/b++Y2bDxkcwmq35Bvxg==}
@@ -2514,6 +2524,7 @@ packages:
   source-map@0.8.0-beta.0:
     resolution: {integrity: sha512-2ymg6oRBpebeZi9UUNsgQ89bhx01TcTkmNTGnNO88imTmbSgy4nfujrgVEFKWpMTEGA11EDkTt7mqObTPdigIA==}
     engines: {node: '>= 8'}
+    deprecated: The work that was done in this beta branch won't be included in future versions
 
   spawndamnit@2.0.0:
     resolution: {integrity: sha512-j4JKEcncSjFlqIwU5L/rp2N5SIPsdxaRsIv678+TZxZ0SRDJTm8JrxJMjE/XuiEZNEir3S8l0Fa3Ke339WI4qA==}
@@ -3691,7 +3702,7 @@ snapshots:
 
   '@shikijs/vscode-textmate@10.0.2': {}
 
-  '@sovereign-sdk/client@0.1.0-alpha.35':
+  '@sovereign-sdk/client@0.1.0-alpha.36':
     dependencies:
       '@types/node': 18.19.54
       '@types/node-fetch': 2.6.11
@@ -4495,7 +4506,6 @@ snapshots:
   get-tsconfig@4.10.1:
     dependencies:
       resolve-pkg-maps: 1.0.0
-    optional: true
 
   glob-parent@5.1.2:
     dependencies:
@@ -5037,8 +5047,7 @@ snapshots:
 
   resolve-from@5.0.0: {}
 
-  resolve-pkg-maps@1.0.0:
-    optional: true
+  resolve-pkg-maps@1.0.0: {}
 
   retry@0.12.0: {}
 
@@ -5379,7 +5388,6 @@ snapshots:
       get-tsconfig: 4.10.1
     optionalDependencies:
       fsevents: 2.3.3
-    optional: true
 
   tweetnacl@0.14.5: {}
 


### PR DESCRIPTION
## Description

Integrates the `serializers` package into `web3`, this unlocks the ability to start using the JS based serializer and the ability to swap between JS and WASM.

The default is still WASM until I investigate the outstanding issue found by fuzzing

Here's how customers can try out the JS impl today:

```ts
  const getSerializer = (schema: RollupSchema) => new JsSerializer(schema);
  const rollup = await createStandardRollup({ getSerializer });

  const runtimeCall = {
    bank: {
      create_token: {
        token_name: "token_3",
        initial_balance: "20000",
        token_decimals: 12,
        supply_cap: "100000000000",
        mint_to_address: testAddress,
        admins: [testAddress],
      },
    },
  };

  rollup.call(runtimeCall, { signer });
```

## Related Issues

<!-- Link to any related issues using #issue_number -->

## Checklist

- [ ] PR contains a changeset entry with minor version bump if it contains any breaking changes ([see here for explanation](../DEVELOPMENT.md#changesets-in-monorepo))
