### PR TITLE
Fixing `pnpm run docs`

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -36,3 +36,5 @@ jobs:
         uses: codecov/codecov-action@v4
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
+      - name: Check docs build
+        run: pnpm run docs

--- a/packages/serializers/src/js/json-to-borsh.ts
+++ b/packages/serializers/src/js/json-to-borsh.ts
@@ -493,7 +493,7 @@ export class JsonToBorshConverter {
     this.writer.writeBool(value);
   }
 
-  private visitByteArray(len: number, _display: any, context: Context): void {
+  private visitByteArray(len: number, display: any, context: Context): void {
     let bytes: number[];
 
     if (Array.isArray(context.value)) {
@@ -510,7 +510,7 @@ export class JsonToBorshConverter {
       });
     } else if (typeof context.value === "string") {
       bytes = byteDisplay.parse(
-        context.currentLink.Immediate.ByteArray.display,
+        display,
         context.value
       );
     } else {
@@ -534,7 +534,7 @@ export class JsonToBorshConverter {
     }
   }
 
-  private visitByteVec(_display: any, context: Context): void {
+  private visitByteVec(display: any, context: Context): void {
     let bytes: number[];
 
     if (Array.isArray(context.value)) {
@@ -551,7 +551,7 @@ export class JsonToBorshConverter {
       });
     } else if (typeof context.value === "string") {
       bytes = byteDisplay.parse(
-        context.currentLink.Immediate.ByteVec.display,
+        display,
         context.value
       );
     } else {

--- a/packages/serializers/src/js/json-to-borsh.ts
+++ b/packages/serializers/src/js/json-to-borsh.ts
@@ -509,8 +509,17 @@ export class JsonToBorshConverter {
         return v;
       });
     } else if (typeof context.value === "string") {
+      // Use the display from context.currentLink if it's an Immediate link,
+      // otherwise use the display parameter passed directly
+      const actualDisplay = 
+        typeof context.currentLink === "object" && 
+        "Immediate" in context.currentLink && 
+        typeof context.currentLink.Immediate === "object" &&
+        "ByteArray" in context.currentLink.Immediate
+          ? context.currentLink.Immediate.ByteArray.display
+          : display;
       bytes = byteDisplay.parse(
-        display,
+        actualDisplay,
         context.value
       );
     } else {
@@ -550,8 +559,17 @@ export class JsonToBorshConverter {
         return v;
       });
     } else if (typeof context.value === "string") {
+      // Use the display from context.currentLink if it's an Immediate link,
+      // otherwise use the display parameter passed directly
+      const actualDisplay = 
+        typeof context.currentLink === "object" && 
+        "Immediate" in context.currentLink && 
+        typeof context.currentLink.Immediate === "object" &&
+        "ByteVec" in context.currentLink.Immediate
+          ? context.currentLink.Immediate.ByteVec.display
+          : display;
       bytes = byteDisplay.parse(
-        display,
+        actualDisplay,
         context.value
       );
     } else {

--- a/packages/serializers/tests/js.test.ts
+++ b/packages/serializers/tests/js.test.ts
@@ -4,7 +4,7 @@ import schema from "./fuzz-input-schema.json";
 
 const js = new JsSerializer(schema);
 
-const byteVecCases = [
+const byteVecCases: Array<[string, any]> = [
   ["Base58", { address: "gFqoeNwi4sf1M" }],
   ["Hex", "0x1717171717171717171717171717171717171717171717171717171717171717"],
   // handles non 0x prefix
@@ -14,7 +14,7 @@ const byteVecCases = [
 ];
 
 // TODO: get 32byte values
-const byteArrayCases = [
+const byteArrayCases: Array<[string, any]> = [
   ["Hex", "0x1717171717171717171717171717171717171717171717171717171717171717"],
   // handles non 0x prefix
   ["Hex", "1717171717171717171717171717171717171717171717171717171717171717"],


### PR DESCRIPTION
## Summary
- Fixed TypeScript compilation errors in the serializers package that were preventing `pnpm run docs` from succeeding
- Properly handles type narrowing for the `Link` union type in byte array/vector serialization

## Problem
The docs build was failing with TypeScript errors:
1. `Property 'Immediate' does not exist on type 'Link'` - The code was trying to access `context.currentLink.Immediate` without proper type guards
2. `A computed property name must be of type 'string', 'number', 'symbol', or 'any'` - Test arrays needed explicit type annotations

## Solution

### 1. Fixed type narrowing for Link union type
The `Link` type is a union that can be:
- `{ ByIndex: number }`
- `{ Immediate: Primitive }` 
- `"Placeholder"`
- `{ IndexedPlaceholder: number }`

The `visitByteArray` and `visitByteVec` methods can be called in two scenarios:
- **Direct**: When `visitType` encounters a `ByteArray`/`ByteVec` type directly
- **Indirect**: When following a link that has an `Immediate` primitive

The fix adds proper type guards to check:
1. If `currentLink` is an object (not the string "Placeholder")
2. If it has the `Immediate` property
3. If `Immediate` is an object (not a string primitive like "Float32")
4. If it has the appropriate property (`ByteArray` or `ByteVec`)

This preserves the original intent of using `currentLink.Immediate` when available while handling the direct call case.

### 2. Added type annotations to test arrays
Explicitly typed `byteVecCases` and `byteArrayCases` as `Array<[string, any]>` to ensure TypeScript treats the format parameter as a string type rather than a union of string literals.

## Test plan
- [x] Verified `pnpm run docs` now runs successfully without TypeScript errors
- [x] All remaining warnings are documentation-related (missing files, unresolved links) not compilation errors
- [x] Maintained backward compatibility for both direct and indirect type resolution paths

🤖 Generated with [Claude Code](https://claude.ai/code)