### PR TITLE
Fix error check eqality

### DIFF
--- a/.changeset/big-lobsters-kick.md
+++ b/.changeset/big-lobsters-kick.md
@@ -1,0 +1,5 @@
+---
+"@sovereign-sdk/modules": patch
+---
+
+bump error check in bank module

--- a/packages/modules/src/bank.ts
+++ b/packages/modules/src/bank.ts
@@ -121,12 +121,13 @@ export class Bank {
     return tokenId ?? this.gasTokenId();
   }
 
-  private isMissingAccountError(anyError: unknown): boolean {
-    if (!(anyError instanceof SovereignClient.APIError)) return false;
-    if (anyError.status !== 404) return false;
-    const body = anyError.error as ErrorResponse;
+  // biome-ignore lint/suspicious/noExplicitAny: todo
+  private isMissingAccountError(anyError: any): boolean {
+    if (anyError?.status !== 404) return false;
+    const body = anyError?.error as ErrorResponse;
     return (
-      body.message.startsWith("Balance") && body.message.endsWith("not found")
+      body?.message?.startsWith("Balance") &&
+      body?.message?.endsWith("not found")
     );
   }
 }


### PR DESCRIPTION
## Description

There's a edge case where the `instanceof` check can incorrectly fail if there's multiple instances of the same package in a bundle. We can just skip it, the rest should be good enough